### PR TITLE
Fix crash on versions < 21 (issue #6)

### DIFF
--- a/triad/src/main/java/com/nhaarman/triad/TriadView.java
+++ b/triad/src/main/java/com/nhaarman/triad/TriadView.java
@@ -37,7 +37,9 @@ public class TriadView<M> extends RelativeLayoutContainer<TriadPresenter<M>, Tri
   }
 
   public TriadView(final Context context, final AttributeSet attrs, final int defStyle) {
-    this(context, attrs, defStyle, 0);
+    super(context, attrs, defStyle);
+
+    mTransitionAnimationDurationMs = getResources().getInteger(android.R.integer.config_shortAnimTime);
   }
 
   public TriadView(final Context context, final AttributeSet attrs, final int defStyleAttr, final int defStyleRes) {


### PR DESCRIPTION
* 4 arg RelativeLayout ctor not available in versions < 21
* Do not pass 3 arg TriadView ctor on to 4 arg ctor