### PR TITLE
Lose container control onStop (#14)

### DIFF
--- a/triad/src/main/java/com/nhaarman/triad/TriadActivity.java
+++ b/triad/src/main/java/com/nhaarman/triad/TriadActivity.java
@@ -84,6 +84,12 @@ public abstract class TriadActivity<M> extends Activity {
   protected abstract Screen<?, ?, M> createInitialScreen();
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mTriadPresenter.onStart();
+  }
+
+  @Override
   protected void onPostCreate(final Bundle savedInstanceState) {
     super.onPostCreate(savedInstanceState);
     Backstack backstack = mFlow.getBackstack();
@@ -102,6 +108,12 @@ public abstract class TriadActivity<M> extends Activity {
     for (Screen screen : screens) {
       mTriadPresenter.showScreen(screen, Flow.Direction.FORWARD);
     }
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mTriadPresenter.onStop();
   }
 
   @Override

--- a/triad/src/main/java/com/nhaarman/triad/TriadPresenter.java
+++ b/triad/src/main/java/com/nhaarman/triad/TriadPresenter.java
@@ -2,6 +2,7 @@ package com.nhaarman.triad;
 
 import android.view.View;
 import android.view.ViewGroup;
+import com.nhaarman.triad.container.Container;
 import com.nhaarman.triad.container.ScreenContainer;
 import com.nhaarman.triad.presenter.Presenter;
 import com.nhaarman.triad.presenter.ScreenPresenter;
@@ -128,6 +129,27 @@ class TriadPresenter<M> extends Presenter<TriadPresenter<M>, TriadContainer<M>> 
 
   public void onDimmerClicked() {
     onBackPressed();
+  }
+
+  public <P extends ScreenPresenter<P, C>, C extends ScreenContainer<P, C>> void onStart() {
+    if (mScreens.empty()) {
+      return;
+    }
+
+    Screen<P, C, M> screen = (Screen<P, C, M>) mScreens.peek();
+    P presenter = screen.getPresenter(mMainComponent);
+    C container = (C) mScreenContainers.peek();
+    presenter.acquire(container);
+  }
+
+  public void onStop() {
+    if (mScreens.empty()) {
+      return;
+    }
+
+    Screen<?, ?, M> screen = mScreens.peek();
+    ScreenPresenter<?, ?> presenter = screen.getPresenter(mMainComponent);
+    presenter.releaseContainer();
   }
 }
 

--- a/triad/src/main/java/com/nhaarman/triad/presenter/Presenter.java
+++ b/triad/src/main/java/com/nhaarman/triad/presenter/Presenter.java
@@ -25,6 +25,14 @@ public class Presenter<P extends Presenter<P, C>, C extends Container<P, C>> {
    * @param container The {@link C} to gain control over.
    */
   public final void acquire(@NotNull final C container) {
+    if (container.equals(mContainer)) {
+      return;
+    }
+
+    if (mContainer != null) {
+      onControlLost();
+    }
+
     mContainer = container;
     onControlGained(container);
   }

--- a/triad/src/main/java/com/nhaarman/triad/presenter/Presenter.java
+++ b/triad/src/main/java/com/nhaarman/triad/presenter/Presenter.java
@@ -24,7 +24,7 @@ public class Presenter<P extends Presenter<P, C>, C extends Container<P, C>> {
    *
    * @param container The {@link C} to gain control over.
    */
-  public final void acquire(@NotNull final C container) {
+  public  void acquire(@NotNull final C container) {
     if (container.equals(mContainer)) {
       return;
     }
@@ -41,7 +41,7 @@ public class Presenter<P extends Presenter<P, C>, C extends Container<P, C>> {
    * Releases the {@link C} this {@code Presenter} controls, and calls {@link #onControlLost()}
    * to notify implementers of this class that the {@link C} is no longer available.
    */
-  public final void releaseContainer() {
+  public  void releaseContainer() {
     mContainer = null;
     onControlLost();
   }

--- a/triad/src/test/java/com/nhaarman/triad/container/RelativeLayoutContainerTest.java
+++ b/triad/src/test/java/com/nhaarman/triad/container/RelativeLayoutContainerTest.java
@@ -22,7 +22,7 @@ public class RelativeLayoutContainerTest {
   }
 
   @Test(expected = NullPointerException.class)
-  public void intially_getPresenterThrowsANullPointerException() {
+  public void initially_getPresenterThrowsANullPointerException() {
     mRelativeLayoutContainer.getPresenter();
   }
 

--- a/triad/src/test/java/com/nhaarman/triad/presenter/PresenterTest.java
+++ b/triad/src/test/java/com/nhaarman/triad/presenter/PresenterTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 
 @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
 public class PresenterTest {
@@ -77,5 +78,39 @@ public class PresenterTest {
     /* Then */
     assertThat(mPresenter.onControlLostCalled, is(true));
     assertThat(mPresenter.onControlGainedCalled, is(false));
+  }
+
+  @Test
+  public void acquiringTheSameContainerTwice_doesNothing() {
+    /* Given */
+    TestRelativeLayoutContainer container = mock(TestRelativeLayoutContainer.class);
+    mPresenter.acquire(container);
+    mPresenter.onControlLostCalled = false;
+    mPresenter.onControlGainedCalled = false;
+
+    /* When */
+    mPresenter.acquire(container);
+
+    /* Then */
+    assertThat(mPresenter.onControlLostCalled, is(false));
+    assertThat(mPresenter.onControlGainedCalled, is(false));
+  }
+
+  @Test
+  public void acquiringAnotherContainer_firstReleasesTheCurrentContainer() {
+    /* Given */
+    TestRelativeLayoutContainer container1 = mock(TestRelativeLayoutContainer.class);
+    TestRelativeLayoutContainer container2 = mock(TestRelativeLayoutContainer.class);
+
+    mPresenter.acquire(container1);
+    mPresenter.onControlLostCalled = false;
+    mPresenter.onControlGainedCalled = false;
+
+    /* When */
+    mPresenter.acquire(container2);
+
+    /* Then */
+    assertThat(mPresenter.onControlLostCalled, is(true));
+    assertThat(mPresenter.onControlGainedCalled, is(true));
   }
 }


### PR DESCRIPTION
Presenters will now receive a call to onControlLost when the activity's onStop method is called.

See #14.