### PR TITLE
Retrieve presenter lazily

### DIFF
--- a/triad/src/main/java/com/nhaarman/triad/LinearLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/LinearLayoutContainer.java
@@ -38,8 +38,8 @@ public abstract class LinearLayoutContainer
 
     /* Use a raw type in favor of an easier API. */
     @SuppressWarnings("rawtypes")
-    @NonNull
-    private final Presenter mPresenter;
+    @Nullable
+    private Presenter mPresenter;
 
     @NonNull
     private final ActivityComponent mActivityComponent;
@@ -60,6 +60,10 @@ public abstract class LinearLayoutContainer
      */
     @NonNull
     public P getPresenter() {
+        if (mPresenter == null) {
+            mPresenter = findPresenter(getContext(), getId());
+        }
+
         return (P) mPresenter;
     }
 
@@ -83,13 +87,14 @@ public abstract class LinearLayoutContainer
             return;
         }
 
-        mPresenter.acquire(this, mActivityComponent);
+        //noinspection rawtypes
+        ((Presenter) getPresenter()).acquire(this, mActivityComponent);
     }
 
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        mPresenter.releaseContainer();
+        getPresenter().releaseContainer();
     }
 }

--- a/triad/src/main/java/com/nhaarman/triad/ListViewContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/ListViewContainer.java
@@ -38,8 +38,8 @@ public abstract class ListViewContainer
 
     /* Use a raw type in favor of an easier API. */
     @SuppressWarnings("rawtypes")
-    @NonNull
-    private final Presenter mPresenter;
+    @Nullable
+    private Presenter mPresenter;
 
     @NonNull
     private final ActivityComponent mActivityComponent;
@@ -60,6 +60,10 @@ public abstract class ListViewContainer
      */
     @NonNull
     public P getPresenter() {
+        if (mPresenter == null) {
+            mPresenter = findPresenter(getContext(), getId());
+        }
+
         return (P) mPresenter;
     }
 
@@ -78,13 +82,14 @@ public abstract class ListViewContainer
             return;
         }
 
-        mPresenter.acquire(this, mActivityComponent);
+        //noinspection rawtypes
+        ((Presenter) getPresenter()).acquire(this, mActivityComponent);
     }
 
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        mPresenter.releaseContainer();
+        getPresenter().releaseContainer();
     }
 }

--- a/triad/src/main/java/com/nhaarman/triad/RelativeLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/RelativeLayoutContainer.java
@@ -36,13 +36,13 @@ public abstract class RelativeLayoutContainer
       <P extends Presenter<?, ActivityComponent>, ActivityComponent>
       extends RelativeLayout implements Container {
 
-    /* Use a raw type in favor of an easier API. */
-    @SuppressWarnings("rawtypes")
-    @NonNull
-    private final Presenter mPresenter;
-
     @NonNull
     private final ActivityComponent mActivityComponent;
+
+    /* Use a raw type in favor of an easier API. */
+    @SuppressWarnings("rawtypes")
+    @Nullable
+    private Presenter mPresenter;
 
     public RelativeLayoutContainer(@NonNull final Context context, @Nullable final AttributeSet attrs) {
         this(context, attrs, 0);
@@ -52,7 +52,6 @@ public abstract class RelativeLayoutContainer
         super(context, attrs, defStyle);
 
         mActivityComponent = findActivityComponent(context);
-        mPresenter = findPresenter(context, getId());
     }
 
     /**
@@ -60,6 +59,10 @@ public abstract class RelativeLayoutContainer
      */
     @NonNull
     public P getPresenter() {
+        if (mPresenter == null) {
+            mPresenter = findPresenter(getContext(), getId());
+        }
+
         return (P) mPresenter;
     }
 
@@ -83,13 +86,14 @@ public abstract class RelativeLayoutContainer
             return;
         }
 
-        mPresenter.acquire(this, mActivityComponent);
+        //noinspection rawtypes
+        ((Presenter) getPresenter()).acquire(this, mActivityComponent);
     }
 
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        mPresenter.releaseContainer();
+        getPresenter().releaseContainer();
     }
 }

--- a/triad/src/main/java/com/nhaarman/triad/TriadUtil.java
+++ b/triad/src/main/java/com/nhaarman/triad/TriadUtil.java
@@ -40,7 +40,7 @@ public class TriadUtil {
             //noinspection unchecked
             return ((ActivityComponentProvider<ActivityComponent>) baseContext).getActivityComponent();
         } else {
-      /* We return null, since the layout editor can not return the Activity Component. */
+            /* We return null, since the layout editor can not return the Activity Component. */
             //noinspection ConstantConditions
             return null;
         }
@@ -57,7 +57,7 @@ public class TriadUtil {
             //noinspection unchecked
             return (P) ((ScreenProvider) baseContext).getCurrentScreen().getPresenter(viewId);
         } else {
-       /* We return null, since the layout editor can not return the ScreenProvider. */
+            /* We return null, since the layout editor can not return the ScreenProvider. */
             //noinspection ConstantConditions
             return null;
         }

--- a/triad/src/test/java/com/nhaarman/triad/RelativeLayoutContainerTest.java
+++ b/triad/src/test/java/com/nhaarman/triad/RelativeLayoutContainerTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -52,30 +53,31 @@ public class RelativeLayoutContainerTest {
         mActivityComponentMock = mock(ActivityComponent.class);
         when(((ActivityComponentProvider<ActivityComponent>) activity).getActivityComponent()).thenReturn(mActivityComponentMock);
 
-        mRelativeLayoutContainer = new TestRelativeLayoutContainer(activity, null, 0);
+        mRelativeLayoutContainer = spy(new TestRelativeLayoutContainer(activity, null, 0));
+        when(mRelativeLayoutContainer.getContext()).thenReturn(activity);
     }
 
     @Test
     public void getPresenter_returnsProperPresenter() {
-    /* Then */
+        /* Then */
         assertThat(mRelativeLayoutContainer.getPresenter(), is(mPresenterMock));
     }
 
     @Test
     public void onAttachedToWindow_givesControlToPresenter() {
-    /* When */
+        /* When */
         mRelativeLayoutContainer.onAttachedToWindow();
 
-    /* Then */
+        /* Then */
         verify(mPresenterMock).acquire(mRelativeLayoutContainer, mActivityComponentMock);
     }
 
     @Test
     public void onDetachedFromWindow_releasesPresenterControl() {
-    /* When */
+        /* When */
         mRelativeLayoutContainer.onDetachedFromWindow();
 
-    /* Then */
+        /* Then */
         verify(mPresenterMock).releaseContainer();
     }
 }


### PR DESCRIPTION
Retrieve the Presenter lazily, for cases where the view id is not known yet in the constructor.
This happens for example with `<include>` tags.