### PR TITLE
Notify screens of creation and destroy

### DIFF
--- a/triad-appcompat-v7/src/main/java/com/nhaarman/triad/TriadAppCompatActivity.java
+++ b/triad-appcompat-v7/src/main/java/com/nhaarman/triad/TriadAppCompatActivity.java
@@ -83,6 +83,12 @@ public abstract class TriadAppCompatActivity<ApplicationComponent, ActivityCompo
         mDelegate.onActivityResult(requestCode, resultCode, data);
     }
 
+    @Override
+    protected void onDestroy() {
+        mDelegate.onDestroy();
+        super.onDestroy();
+    }
+
     /**
      * Returns the {@link Triad} instance to be used to navigate between {@link Screen}s.
      */

--- a/triad/src/main/java/com/nhaarman/triad/Backstack.java
+++ b/triad/src/main/java/com/nhaarman/triad/Backstack.java
@@ -124,8 +124,12 @@ public class Backstack implements Iterable<Screen<?>> {
 
         @NonNull
         public Builder push(@NonNull final Screen<?> screen, @Nullable final TransitionAnimator animator) {
-            mBackstack.push(new Entry(screen, animator));
+            return push(new Entry(screen, animator));
+        }
 
+        @NonNull
+        public Builder push(@NonNull final Entry<?> entry) {
+            mBackstack.push(entry);
             return this;
         }
 

--- a/triad/src/main/java/com/nhaarman/triad/Screen.java
+++ b/triad/src/main/java/com/nhaarman/triad/Screen.java
@@ -57,10 +57,6 @@ public abstract class Screen<ApplicationComponent> {
     @NonNull
     protected abstract Presenter<?, ?> createPresenter(int viewId);
 
-    boolean onBackPressed() {
-        return false;
-    }
-
     void setApplicationComponent(@Nullable final ApplicationComponent applicationComponent) {
         mApplicationComponent = applicationComponent;
     }
@@ -76,5 +72,15 @@ public abstract class Screen<ApplicationComponent> {
 
     void restoreState(@NonNull final ViewGroup view) {
         view.restoreHierarchyState(mState);
+    }
+
+    protected void onCreate() {
+    }
+
+    protected boolean onBackPressed() {
+        return false;
+    }
+
+    protected void onDestroy() {
     }
 }

--- a/triad/src/main/java/com/nhaarman/triad/Triad.java
+++ b/triad/src/main/java/com/nhaarman/triad/Triad.java
@@ -301,6 +301,10 @@ public class Triad {
 
     public interface Listener<T> {
 
+        void screenPushed(@NonNull Screen<T> pushedScreen);
+
+        void screenPopped(@NonNull Screen<T> poppedScreen);
+
         /**
          * Notifies the listener that the backstack will forward to a new Screen.
          *
@@ -349,21 +353,33 @@ public class Triad {
             }
         }
 
-        protected void forward(@NonNull final Backstack nextBackstack) {
+        protected void notifyScreenPopped(@NonNull final Screen<?> screen) {
+            checkState(mListener != null, "Listener is null. Be sure to call setListener(Listener).");
+
+            mListener.screenPopped(screen);
+        }
+
+        protected void notifyScreenPushed(@NonNull final Screen<?> screen) {
+            checkState(mListener != null, "Listener is null. Be sure to call setListener(Listener).");
+
+            mListener.screenPushed(screen);
+        }
+
+        protected void notifyForward(@NonNull final Backstack nextBackstack) {
             checkState(mListener != null, "Listener is null. Be sure to call setListener(Listener).");
 
             mNextBackstack = nextBackstack;
             mListener.forward(nextBackstack.current().screen, nextBackstack.current().animator, this);
         }
 
-        protected void backward(@NonNull final Backstack nextBackstack, @Nullable final TransitionAnimator animator) {
+        protected void notifyBackward(@NonNull final Backstack nextBackstack, @Nullable final TransitionAnimator animator) {
             checkState(mListener != null, "Listener is null. Be sure to call setListener(Listener).");
 
             mNextBackstack = nextBackstack;
             mListener.backward(nextBackstack.current().screen, animator, this);
         }
 
-        protected void replace(@NonNull final Backstack nextBackstack) {
+        protected void notifyReplace(@NonNull final Backstack nextBackstack) {
             checkState(mListener != null, "Listener is null. Be sure to call setListener(Listener).");
 
             mNextBackstack = nextBackstack;
@@ -403,7 +419,9 @@ public class Triad {
                 Backstack.Builder builder = mBackstack.buildUpon();
                 Backstack.Entry<?> entry = checkNotNull(builder.pop(), "Popped entry is null.");
                 Backstack newBackstack = builder.build();
-                backward(newBackstack, entry.animator);
+
+                notifyScreenPopped(entry.screen);
+                notifyBackward(newBackstack, entry.animator);
             }
         }
     }
@@ -424,11 +442,13 @@ public class Triad {
         @Override
         public void execute() {
             Backstack.Builder builder = mBackstack.buildUpon();
-            builder.pop();
+            Backstack.Entry<?> entry = checkNotNull(builder.pop(), "Popped entry is null");
             builder.push(mScreen, mAnimator);
             Backstack newBackstack = builder.build();
 
-            replace(newBackstack);
+            notifyScreenPopped(entry.screen);
+            notifyScreenPushed(mScreen);
+            notifyReplace(newBackstack);
         }
     }
 
@@ -443,7 +463,14 @@ public class Triad {
 
         @Override
         public void execute() {
-            forward(mNewBackstack);
+            for (Screen<?> screen : mBackstack) {
+                notifyScreenPopped(screen);
+            }
+            for (Iterator<Screen<?>> it = mNewBackstack.reverseIterator(); it.hasNext(); ) {
+                notifyScreenPushed(it.next());
+            }
+
+            notifyForward(mNewBackstack);
         }
     }
 
@@ -468,18 +495,21 @@ public class Triad {
             }
 
             Backstack.Builder builder = mBackstack.buildUpon();
+            Backstack.Builder poppedScreens = Backstack.emptyBuilder();
             int count = 0;
             // Take care to leave the original screen instance on the stack, if we find it.  This enables
             // some arguably bad behavior on the part of clients, but it's still probably the right thing
             // to do.
-            Backstack.Entry<?> lastPoppedEntry = null;
             for (Iterator<Backstack.Entry<?>> it = mBackstack.reverseEntryIterator(); it.hasNext(); ) {
                 Screen<?> screen = it.next().screen;
 
                 if (screen.equals(mScreen)) {
                     // Clear up to the target screen.
                     for (int i = 0; i < mBackstack.size() - count; i++) {
-                        lastPoppedEntry = builder.pop();
+                        Backstack.Entry<?> entry = builder.pop();
+                        if (entry != null) {
+                            poppedScreens.push(entry);
+                        }
                     }
                     break;
                 } else {
@@ -488,14 +518,22 @@ public class Triad {
             }
 
             Backstack newBackstack;
-            if (lastPoppedEntry != null) {
-                builder.push(lastPoppedEntry.screen, lastPoppedEntry.animator);
+            Backstack poppedBackstack = poppedScreens.build();
+            if (poppedBackstack.size() != 0) {
+                for (Iterator<Backstack.Entry<?>> it = poppedBackstack.reverseEntryIterator(); it.hasNext(); ) {
+                    Backstack.Entry<?> entry = it.next();
+                    notifyScreenPopped(entry.screen);
+                }
+
+                builder.push(poppedBackstack.current());
                 newBackstack = builder.build();
-                backward(newBackstack, mAnimator);
+                notifyBackward(newBackstack, mAnimator);
             } else {
+                notifyScreenPushed(mScreen);
+
                 builder.push(mScreen, mAnimator);
                 newBackstack = builder.build();
-                forward(newBackstack);
+                notifyForward(newBackstack);
             }
         }
     }
@@ -504,7 +542,7 @@ public class Triad {
 
         @Override
         public void execute() {
-            forward(mBackstack);
+            notifyForward(mBackstack);
         }
     }
 
@@ -519,8 +557,9 @@ public class Triad {
 
         @Override
         public void execute() {
-            Backstack newBackstack = mBackstack.buildUpon().push(mScreen).build();
-            forward(newBackstack);
+            Backstack newBackstack = Backstack.single(mScreen);
+            notifyScreenPushed(mScreen);
+            notifyForward(newBackstack);
         }
     }
 
@@ -540,7 +579,8 @@ public class Triad {
         @Override
         public void execute() {
             Backstack newBackstack = mBackstack.buildUpon().push(mScreen, mAnimator).build();
-            forward(newBackstack);
+            notifyScreenPushed(mScreen);
+            notifyForward(newBackstack);
         }
     }
 
@@ -555,7 +595,14 @@ public class Triad {
 
         @Override
         public void execute() {
-            backward(mNewBackstack, null);
+            for (Screen<?> screen : mBackstack) {
+                notifyScreenPopped(screen);
+            }
+            for (Iterator<Screen<?>> it = mNewBackstack.reverseIterator(); it.hasNext(); ) {
+                notifyScreenPushed(it.next());
+            }
+
+            notifyBackward(mNewBackstack, null);
         }
     }
 
@@ -570,7 +617,14 @@ public class Triad {
 
         @Override
         public void execute() {
-            replace(mNewBackstack);
+            for (Screen<?> screen : mBackstack) {
+                notifyScreenPopped(screen);
+            }
+            for (Iterator<Screen<?>> it = mNewBackstack.reverseIterator(); it.hasNext(); ) {
+                notifyScreenPushed(it.next());
+            }
+
+            notifyReplace(mNewBackstack);
         }
     }
 }

--- a/triad/src/main/java/com/nhaarman/triad/TriadActivity.java
+++ b/triad/src/main/java/com/nhaarman/triad/TriadActivity.java
@@ -81,6 +81,12 @@ public abstract class TriadActivity<ApplicationComponent, ActivityComponent> ext
         mDelegate.onActivityResult(requestCode, resultCode, data);
     }
 
+    @Override
+    protected void onDestroy() {
+        mDelegate.onDestroy();
+        super.onDestroy();
+    }
+
     /**
      * Returns the {@link Triad} instance to be used to navigate between {@link Screen}s.
      */

--- a/triad/src/main/java/com/nhaarman/triad/TriadDelegate.java
+++ b/triad/src/main/java/com/nhaarman/triad/TriadDelegate.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.SparseArray;
 import android.view.ViewGroup;
+import java.util.Iterator;
 
 import static com.nhaarman.triad.Preconditions.checkNotNull;
 import static com.nhaarman.triad.Preconditions.checkState;
@@ -111,6 +112,15 @@ public class TriadDelegate<ApplicationComponent> {
         mTriad.onActivityResult(requestCode, resultCode, data);
     }
 
+    public void onDestroy() {
+        checkState(mTriad != null, "Triad is null. Make sure to call TriadDelegate.onCreate()");
+
+        for (Iterator<Screen<?>> iterator = mTriad.getBackstack().reverseIterator(); iterator.hasNext(); ) {
+            Screen<?> screen = iterator.next();
+            screen.onDestroy();
+        }
+    }
+
     /**
      * Returns the {@link Triad} instance to be used to navigate between {@link Screen}s.
      */
@@ -140,6 +150,16 @@ public class TriadDelegate<ApplicationComponent> {
     }
 
     private class MyTriadListener implements Triad.Listener<ApplicationComponent> {
+
+        @Override
+        public void screenPushed(@NonNull final Screen<ApplicationComponent> pushedScreen) {
+            pushedScreen.onCreate();
+        }
+
+        @Override
+        public void screenPopped(@NonNull final Screen<ApplicationComponent> poppedScreen) {
+            poppedScreen.onDestroy();
+        }
 
         @Override
         public void forward(@NonNull final Screen<ApplicationComponent> newScreen, @Nullable final TransitionAnimator animator, @NonNull final Triad.Callback callback) {

--- a/triad/src/test/java/com/nhaarman/triad/TriadDelegateTest.java
+++ b/triad/src/test/java/com/nhaarman/triad/TriadDelegateTest.java
@@ -1,0 +1,58 @@
+package com.nhaarman.triad;
+
+import android.app.Activity;
+import android.app.Application;
+import android.view.View;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockSettings;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class TriadDelegateTest {
+
+    @Mock
+    private Activity mActivity;
+
+    private Application mApplication;
+
+    @Mock
+    private Triad.Listener<Object> mListener;
+
+    @Mock
+    private Screen<Object> mScreen1;
+
+    @Mock
+    private Screen<Object> mScreen2;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+
+        mApplication = mock(Application.class, withSettings().extraInterfaces(TriadProvider.class, ApplicationComponentProvider.class));
+
+        when(mActivity.getApplication()).thenReturn(mApplication);
+        when(mActivity.findViewById(anyInt())).thenReturn(mock(TriadView.class));
+    }
+
+    @Test
+    public void onDestroy_notifiesBackstackScreenPopped() {
+        /* Given */
+        TriadDelegate<Object> delegate = TriadDelegate.createFor(mActivity);
+        when(((TriadProvider) mApplication).getTriad()).thenReturn(Triad.newInstance(Backstack.of(mScreen1, mScreen2), mListener));
+        delegate.onCreate();
+
+        /* When */
+        delegate.onDestroy();
+
+        /* Then */
+        verify(mScreen2).onDestroy();
+        verify(mScreen1).onDestroy();
+    }
+}


### PR DESCRIPTION
This PR notifies screens when they are pushed onto the stack (`onCreate()`), and when they are popped off the stack (`onDestroy()`). 

Implementers of the `Screen` class can override these methods to hook in.