### PR TITLE
Screen lifecycle

### DIFF
--- a/triad-core/src/main/kotlin/com/nhaarman/triad/Screen.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/Screen.kt
@@ -16,6 +16,7 @@
 
 package com.nhaarman.triad
 
+import android.app.Activity
 import android.os.Parcelable
 import android.util.SparseArray
 import android.view.LayoutInflater
@@ -33,10 +34,12 @@ abstract class Screen<ApplicationComponent : Any> {
     protected abstract val layoutResId: Int
 
     open fun createView(parent: ViewGroup): View {
+        println("createView")
         return LayoutInflater.from(parent.context).inflate(layoutResId, parent, false)
     }
 
     open fun getPresenter(viewId: Int): Presenter<*, *> {
+        println("getPresenter")
         var presenter = presenters.get(viewId)
 
         if (presenter == null) {
@@ -50,24 +53,37 @@ abstract class Screen<ApplicationComponent : Any> {
     protected abstract fun createPresenter(viewId: Int): Presenter<*, *>
 
     internal fun setApplicationComponent(applicationComponent: ApplicationComponent) {
+        println("setApplicationComponent")
         this.applicationComponent = applicationComponent
     }
 
     internal fun saveState(view: View) {
+        println("saveState")
         view.saveHierarchyState(state)
     }
 
     internal fun restoreState(view: View) {
+        println("restoreState")
         view.restoreHierarchyState(state)
     }
 
     open fun onCreate() {
+        println("onCreate")
+    }
+
+    open fun onAttach(activity: Activity) {
+        println("onAttach")
     }
 
     open fun onBackPressed(): Boolean {
         return false
     }
 
+    open fun onDetach(activity: Activity) {
+        println("onDetach")
+    }
+
     open fun onDestroy() {
+        println("onDestroy")
     }
 }

--- a/triad-core/src/main/kotlin/com/nhaarman/triad/TriadActivity.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/TriadActivity.kt
@@ -23,7 +23,7 @@ import android.os.Bundle
 /**
  * An [Activity] which is the root of an application that uses Triad.
 
- * @param  The `ApplicationComponent` to use for `BasePresenter` creation.
+ * @param  The `ApplicationComponent` to use for `Presenter` creation.
  * *
  * @param     The `ActivityComponent` to supply to `Presenters`.
  */
@@ -43,6 +43,11 @@ abstract class TriadActivity<ApplicationComponent : Any, ActivityComponent> : Ac
         delegate.onCreate()
     }
 
+    override fun onResume() {
+        super.onResume()
+        delegate.onResume()
+    }
+
     /**
      * Creates the `ActivityComponent`.
      */
@@ -56,6 +61,11 @@ abstract class TriadActivity<ApplicationComponent : Any, ActivityComponent> : Ac
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
         delegate.onActivityResult(requestCode, resultCode, data)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        delegate.onPause()
     }
 
     override fun onDestroy() {

--- a/triad-core/src/main/kotlin/com/nhaarman/triad/TriadDelegate.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/TriadDelegate.kt
@@ -83,12 +83,20 @@ class TriadDelegate<ApplicationComponent : Any> private constructor(
         }
     }
 
+    fun onResume() {
+        _currentScreen?.onAttach(activity)
+    }
+
     fun onBackPressed(): Boolean {
         return _currentScreen != null && _currentScreen!!.onBackPressed() || triad.goBack()
     }
 
     fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
         triad.onActivityResult(requestCode, resultCode, data)
+    }
+
+    fun onPause() {
+        _currentScreen?.onDetach(activity)
     }
 
     fun onDestroy() {

--- a/triad-core/src/main/kotlin/com/nhaarman/triad/TriadDelegate.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/TriadDelegate.kt
@@ -92,6 +92,8 @@ class TriadDelegate<ApplicationComponent : Any> private constructor(
     }
 
     fun onDestroy() {
+        if (!activity.isFinishing) return
+
         val iterator = triad.backstack.reverseIterator()
         while (iterator.hasNext()) {
             val screen = iterator.next()

--- a/triad-kotlin/src/test/kotlin/com/nhaarman/triad/TriadDelegateTest.kt
+++ b/triad-kotlin/src/test/kotlin/com/nhaarman/triad/TriadDelegateTest.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.app.Application
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
 import org.junit.Test
@@ -56,8 +57,10 @@ class TriadDelegateTest {
     }
 
     @Test
-    fun onDestroy_notifiesBackstackScreenPopped() {
+    fun onDestroy_finishing_notifiesBackstackScreenPopped() {
         /* Given */
+        whenever(activity.isFinishing).thenReturn(true)
+
         val delegate = TriadDelegate.createFor<Any>(activity)
         whenever((mApplication as TriadProvider).triad).thenReturn(Triad.newInstance(Backstack.of(mScreen1, mScreen2), mListener))
         delegate.onCreate()
@@ -68,5 +71,22 @@ class TriadDelegateTest {
         /* Then */
         verify(mScreen2).onDestroy()
         verify(mScreen1).onDestroy()
+    }
+
+    @Test
+    fun onDestroy_notFinishing_doesNotNotifyScreens() {
+        /* Given */
+        whenever(activity.isFinishing).thenReturn(false)
+
+        val delegate = TriadDelegate.createFor<Any>(activity)
+        whenever((mApplication as TriadProvider).triad).thenReturn(Triad.newInstance(Backstack.of(mScreen1, mScreen2), mListener))
+        delegate.onCreate()
+
+        /* When */
+        delegate.onDestroy()
+
+        /* Then */
+        verify(mScreen2, never()).onDestroy()
+        verify(mScreen1, never()).onDestroy()
     }
 }

--- a/triad/src/test/java/com/nhaarman/triad/TriadDelegateTest.java
+++ b/triad/src/test/java/com/nhaarman/triad/TriadDelegateTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mock;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -59,8 +60,10 @@ public class TriadDelegateTest {
     }
 
     @Test
-    public void onDestroy_notifiesBackstackScreenPopped() {
+    public void onDestroy_finishing_notifiesBackstackScreenPopped() {
         /* Given */
+        when(mActivity.isFinishing()).thenReturn(true);
+
         TriadDelegate<Object> delegate = TriadDelegate.Companion.createFor(mActivity);
         when(((TriadProvider) mApplication).getTriad()).thenReturn(Triad.Companion.newInstance(Backstack.Companion.of(mScreen1, mScreen2), mListener));
         delegate.onCreate();
@@ -71,5 +74,22 @@ public class TriadDelegateTest {
         /* Then */
         verify(mScreen2).onDestroy();
         verify(mScreen1).onDestroy();
+    }
+
+    @Test
+    public void onDestroy_notFinishing_doesNotNotifyScreens() {
+        /* Given */
+        when(mActivity.isFinishing()).thenReturn(false);
+
+        TriadDelegate<Object> delegate = TriadDelegate.Companion.createFor(mActivity);
+        when(((TriadProvider) mApplication).getTriad()).thenReturn(Triad.Companion.newInstance(Backstack.Companion.of(mScreen1, mScreen2), mListener));
+        delegate.onCreate();
+
+        /* When */
+        delegate.onDestroy();
+
+        /* Then */
+        verify(mScreen2, never()).onDestroy();
+        verify(mScreen1, never()).onDestroy();
     }
 }


### PR DESCRIPTION
Added `onAttach(Activity)` and `onDetach(Activity)` lifecycle events to `Screen`, and fixed improper call to `Screen.onDestroy()`.