### PR TITLE
Don't release non-held container

### DIFF
--- a/triad-core/src/main/kotlin/com/nhaarman/triad/Presenter.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/Presenter.kt
@@ -59,5 +59,5 @@ interface Presenter<C : Container, ActivityComponent> {
      * the [Container] instance supplied to [.acquire] anymore.
      */
     @MainThread
-    fun releaseContainer()
+    fun releaseContainer(container: C)
 }

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterLinearLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterLinearLayoutContainer.kt
@@ -40,7 +40,7 @@ abstract class AdapterLinearLayoutContainer<P : Presenter<*, ActivityComponent>,
     @Suppress("UNCHECKED_CAST")
     override var presenter: P? = null
         set(value) {
-            field?.releaseContainer()
+            field?.let { (it as Presenter<Container, ActivityComponent>).releaseContainer(this) }
             field = value
             value?.let {
                 if (attachedToWindow) {
@@ -60,10 +60,13 @@ abstract class AdapterLinearLayoutContainer<P : Presenter<*, ActivityComponent>,
         attachedToWindow = true
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
-        presenter?.releaseContainer()
+        presenter?.let {
+            (it as Presenter<Container, ActivityComponent>).releaseContainer(this)
+        }
 
         attachedToWindow = false
     }

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterRelativeLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterRelativeLayoutContainer.kt
@@ -35,14 +35,13 @@ abstract class AdapterRelativeLayoutContainer<P : Presenter<*, ActivityComponent
     private var attachedToWindow: Boolean = false
 
     /**
-     * Returns the [P] instance that is tied to this `RelativeLayoutContainer`.
+     * Returns the [P] instance that is tied to this `AdapterRelativeLayoutContainer`.
      */
     @Suppress("UNCHECKED_CAST")
     override var presenter: P? = null
         set(value) {
-            field?.releaseContainer()
+            field?.let { (it as Presenter<Container, ActivityComponent>).releaseContainer(this) }
             field = value
-
             value?.let {
                 if (attachedToWindow) {
                     (it as Presenter<Container, ActivityComponent>).acquire(this, activityComponent)
@@ -61,10 +60,13 @@ abstract class AdapterRelativeLayoutContainer<P : Presenter<*, ActivityComponent
         attachedToWindow = true
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
-        presenter?.releaseContainer()
+        presenter?.let {
+            (it as Presenter<Container, ActivityComponent>).releaseContainer(this)
+        }
 
         attachedToWindow = false
     }

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/BasePresenter.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/BasePresenter.kt
@@ -81,12 +81,12 @@ open class BasePresenter<C : Container, ActivityComponent> : Presenter<C, Activi
      * to notify implementers of this class that the [C] is no longer available.
      */
     @MainThread
-    override fun releaseContainer() {
-        if (container == null) {
+    override fun releaseContainer(container: C) {
+        if (this.container != container) {
             return
         }
 
-        container = null
+        this.container = null
         activityComponent = null
         onControlLost()
     }

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/LinearLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/LinearLayoutContainer.kt
@@ -37,10 +37,11 @@ abstract class LinearLayoutContainer<P : Presenter<*, ActivityComponent>, Activi
         (presenter as Presenter<Container, ActivityComponent>).acquire(this, activityComponent)
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
-        presenter.releaseContainer()
+        (presenter as Presenter<Container, ActivityComponent>).releaseContainer(this)
     }
 
     override final fun context() = context

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/ListViewContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/ListViewContainer.kt
@@ -40,10 +40,11 @@ abstract class ListViewContainer<P : Presenter<*, ActivityComponent>, ActivityCo
         (presenter as Presenter<Container, ActivityComponent>).acquire(this, activityComponent)
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
-        presenter.releaseContainer()
+        (presenter as Presenter<Container, ActivityComponent>).releaseContainer(this)
     }
 
     override final fun context() = context

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/RelativeLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/RelativeLayoutContainer.kt
@@ -46,9 +46,11 @@ abstract class RelativeLayoutContainer<P : Presenter<*, ActivityComponent>, Acti
         (presenter as Presenter<Container, ActivityComponent>).acquire(this, activityComponent)
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        presenter.releaseContainer()
+
+        (presenter as Presenter<Container, ActivityComponent>).releaseContainer(this)
     }
 
     override final fun context() = context

--- a/triad-kotlin/src/test/kotlin/com/nhaarman/triad/BasePresenterTest.kt
+++ b/triad-kotlin/src/test/kotlin/com/nhaarman/triad/BasePresenterTest.kt
@@ -68,10 +68,11 @@ class BasePresenterTest {
     @Test
     fun afterReleasingContainer_theContainerIsNotPresent() {
         /* Given */
-        presenter.acquire(mock(), mock())
+        val container = mock<TestRelativeLayoutContainer>()
+        presenter.acquire(container, mock())
 
         /* When */
-        presenter.releaseContainer()
+        presenter.releaseContainer(container)
 
         /* Then */
         expect(presenter.container).toBeNull()
@@ -80,10 +81,11 @@ class BasePresenterTest {
     @Test
     fun afterReleasingContainer_theActivityComponentIsNotPresent() {
         /* Given */
-        presenter.acquire(mock(), mock())
+        val container = mock<TestRelativeLayoutContainer>()
+        presenter.acquire(container, mock())
 
         /* When */
-        presenter.releaseContainer()
+        presenter.releaseContainer(container)
 
         /* Then */
         expect(presenter.activityComponent).toBeNull()
@@ -110,7 +112,7 @@ class BasePresenterTest {
         presenter.onControlGainedCalled = false
 
         /* When */
-        presenter.releaseContainer()
+        presenter.releaseContainer(container)
 
         /* Then */
         expect(presenter.onControlLostCalled).toBe(true)
@@ -149,5 +151,23 @@ class BasePresenterTest {
         /* Then */
         expect(presenter.onControlLostCalled).toBe(true)
         expect(presenter.onControlGainedCalled).toBe(true)
+    }
+
+
+    @Test
+    fun releasingADifferentContainer_doesNotCallOnControlLost() {
+        /* Given */
+        val container1 = mock<TestRelativeLayoutContainer>()
+        val container2 = mock<TestRelativeLayoutContainer>()
+
+        presenter.acquire(container1, mock())
+        presenter.onControlLostCalled = false
+        presenter.onControlGainedCalled = false
+
+        /* When */
+        presenter.releaseContainer(container2)
+
+        /* Then */
+        expect(presenter.onControlLostCalled).toBe(false)
     }
 }

--- a/triad-kotlin/src/test/kotlin/com/nhaarman/triad/RelativeLayoutContainerTest.kt
+++ b/triad-kotlin/src/test/kotlin/com/nhaarman/triad/RelativeLayoutContainerTest.kt
@@ -76,6 +76,6 @@ class RelativeLayoutContainerTest {
         relativeLayoutContainer.onDetachedFromWindow()
 
         /* Then */
-        verify(presenterMock).releaseContainer()
+        verify(presenterMock).releaseContainer(relativeLayoutContainer)
     }
 }

--- a/triad/src/main/java/com/nhaarman/triad/AdapterLinearLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/AdapterLinearLayoutContainer.java
@@ -22,8 +22,6 @@ import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 import butterknife.ButterKnife;
-import com.nhaarman.triad.Container;
-import com.nhaarman.triad.Presenter;
 
 import static com.nhaarman.triad.Preconditions.checkState;
 import static com.nhaarman.triad.TriadUtil.findActivityComponent;
@@ -71,7 +69,7 @@ public abstract class AdapterLinearLayoutContainer
     @Override
     public void setPresenter(@NonNull final P presenter) {
         if (mPresenter != null) {
-            mPresenter.releaseContainer();
+            mPresenter.releaseContainer(this);
         }
 
         mPresenter = presenter;
@@ -104,7 +102,7 @@ public abstract class AdapterLinearLayoutContainer
         super.onDetachedFromWindow();
 
         if (mPresenter != null) {
-            mPresenter.releaseContainer();
+            mPresenter.releaseContainer(this);
         }
 
         mIsAttachedToWindow = false;

--- a/triad/src/main/java/com/nhaarman/triad/AdapterRelativeLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/AdapterRelativeLayoutContainer.java
@@ -69,7 +69,7 @@ public abstract class AdapterRelativeLayoutContainer
     @Override
     public void setPresenter(@NonNull final P presenter) {
         if (mPresenter != null) {
-            mPresenter.releaseContainer();
+            mPresenter.releaseContainer(this);
         }
 
         mPresenter = presenter;
@@ -102,7 +102,7 @@ public abstract class AdapterRelativeLayoutContainer
         super.onDetachedFromWindow();
 
         if (mPresenter != null) {
-            mPresenter.releaseContainer();
+            mPresenter.releaseContainer(this);
         }
 
         mIsAttachedToWindow = false;

--- a/triad/src/main/java/com/nhaarman/triad/BasePresenter.java
+++ b/triad/src/main/java/com/nhaarman/triad/BasePresenter.java
@@ -48,7 +48,7 @@ public class BasePresenter<C extends Container, ActivityComponent> implements Pr
      * The {@link Container} this {@link BasePresenter} controls.
      */
     @NonNull
-    private Optional<C> mContainer = Optional.empty();
+    private Optional<C> mCurrentContainer = Optional.empty();
 
     @NonNull
     private Optional<Resources> mResources = Optional.empty();
@@ -65,15 +65,15 @@ public class BasePresenter<C extends Container, ActivityComponent> implements Pr
     @Override
     @MainThread
     public final void acquire(@NonNull final C container, @NonNull final ActivityComponent activityComponent) {
-        if (mContainer.isPresent() && container.equals(mContainer.get())) {
+        if (mCurrentContainer.isPresent() && container.equals(mCurrentContainer.get())) {
             return;
         }
 
-        if (mContainer.isPresent()) {
+        if (mCurrentContainer.isPresent()) {
             onControlLost();
         }
 
-        mContainer = Optional.of(container);
+        mCurrentContainer = Optional.of(container);
         mResources = resources(container);
         mActivityComponent = activityComponent;
         onControlGained(container, activityComponent);
@@ -87,7 +87,7 @@ public class BasePresenter<C extends Container, ActivityComponent> implements Pr
      */
     @VisibleForTesting
     public final void setContainer(@NonNull final C container) {
-        mContainer = Optional.of(container);
+        mCurrentContainer = Optional.of(container);
         mResources = resources(container);
     }
 
@@ -107,12 +107,12 @@ public class BasePresenter<C extends Container, ActivityComponent> implements Pr
      */
     @Override
     @MainThread
-    public final void releaseContainer() {
-        if (!mContainer.isPresent()) {
+    public final void releaseContainer(@NonNull final C container) {
+        if (!mCurrentContainer.isPresent() || !mCurrentContainer.get().equals(container)) {
             return;
         }
 
-        mContainer = Optional.empty();
+        mCurrentContainer = Optional.empty();
         mResources = Optional.empty();
         mActivityComponent = null;
         onControlLost();
@@ -150,7 +150,7 @@ public class BasePresenter<C extends Container, ActivityComponent> implements Pr
      */
     @NonNull
     public Optional<C> container() {
-        return mContainer;
+        return mCurrentContainer;
     }
 
     /**

--- a/triad/src/main/java/com/nhaarman/triad/LinearLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/LinearLayoutContainer.java
@@ -22,8 +22,6 @@ import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 import butterknife.ButterKnife;
-import com.nhaarman.triad.Container;
-import com.nhaarman.triad.Presenter;
 
 import static com.nhaarman.triad.TriadUtil.findActivityComponent;
 import static com.nhaarman.triad.TriadUtil.findPresenter;
@@ -38,13 +36,12 @@ public abstract class LinearLayoutContainer
       <P extends Presenter<?, ActivityComponent>, ActivityComponent>
       extends LinearLayout implements Container {
 
+    @NonNull
+    private final ActivityComponent mActivityComponent;
     /* Use a raw type in favor of an easier API. */
     @SuppressWarnings("rawtypes")
     @Nullable
     private Presenter mPresenter;
-
-    @NonNull
-    private final ActivityComponent mActivityComponent;
 
     public LinearLayoutContainer(@NonNull final Context context, @Nullable final AttributeSet attrs) {
         this(context, attrs, 0);
@@ -96,6 +93,7 @@ public abstract class LinearLayoutContainer
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        getPresenter().releaseContainer();
+        //noinspection rawtypes
+        ((Presenter) getPresenter()).releaseContainer(this);
     }
 }

--- a/triad/src/main/java/com/nhaarman/triad/ListViewContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/ListViewContainer.java
@@ -36,13 +36,12 @@ public abstract class ListViewContainer
       <P extends Presenter<?, ActivityComponent>, ActivityComponent>
       extends ListView implements Container {
 
+    @NonNull
+    private final ActivityComponent mActivityComponent;
     /* Use a raw type in favor of an easier API. */
     @SuppressWarnings("rawtypes")
     @Nullable
     private Presenter mPresenter;
-
-    @NonNull
-    private final ActivityComponent mActivityComponent;
 
     public ListViewContainer(@NonNull final Context context, @Nullable final AttributeSet attrs) {
         this(context, attrs, 0);
@@ -89,7 +88,8 @@ public abstract class ListViewContainer
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        getPresenter().releaseContainer();
+        //noinspection rawtypes
+        ((Presenter) getPresenter()).releaseContainer(this);
     }
 
     @NonNull

--- a/triad/src/main/java/com/nhaarman/triad/RelativeLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/RelativeLayoutContainer.java
@@ -94,7 +94,8 @@ public abstract class RelativeLayoutContainer
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        getPresenter().releaseContainer();
+        //noinspection rawtypes
+        ((Presenter) getPresenter()).releaseContainer(this);
     }
 
     @NonNull

--- a/triad/src/test/java/com/nhaarman/triad/BasePresenterTest.java
+++ b/triad/src/test/java/com/nhaarman/triad/BasePresenterTest.java
@@ -70,10 +70,11 @@ public class BasePresenterTest {
     @Test
     public void afterReleasingContainer_theContainerIsNotPresent() {
     /* Given */
-        mPresenter.acquire(mock(TestRelativeLayoutContainer.class), mock(ActivityComponent.class));
+        TestRelativeLayoutContainer container = mock(TestRelativeLayoutContainer.class);
+        mPresenter.acquire(container, mock(ActivityComponent.class));
 
     /* When */
-        mPresenter.releaseContainer();
+        mPresenter.releaseContainer(container);
 
     /* Then */
         assertThat(mPresenter.container().isPresent(), is(false));
@@ -82,10 +83,11 @@ public class BasePresenterTest {
     @Test
     public void afterReleasingContainer_theActivityComponentIsNotPresent() {
     /* Given */
-        mPresenter.acquire(mock(TestRelativeLayoutContainer.class), mock(ActivityComponent.class));
+        TestRelativeLayoutContainer container = mock(TestRelativeLayoutContainer.class);
+        mPresenter.acquire(container, mock(ActivityComponent.class));
 
     /* When */
-        mPresenter.releaseContainer();
+        mPresenter.releaseContainer(container);
 
     /* Then */
         assertThat(mPresenter.activityComponent().isPresent(), is(false));
@@ -112,7 +114,7 @@ public class BasePresenterTest {
         mPresenter.onControlGainedCalled = false;
 
     /* When */
-        mPresenter.releaseContainer();
+        mPresenter.releaseContainer(container);
 
     /* Then */
         assertThat(mPresenter.onControlLostCalled, is(true));
@@ -151,5 +153,22 @@ public class BasePresenterTest {
     /* Then */
         assertThat(mPresenter.onControlLostCalled, is(true));
         assertThat(mPresenter.onControlGainedCalled, is(true));
+    }
+
+    @Test
+    public void releasingADifferentContainer_doesNotCallOnControlLost() {
+       /* Given */
+        TestRelativeLayoutContainer container1 = mock(TestRelativeLayoutContainer.class);
+        TestRelativeLayoutContainer container2 = mock(TestRelativeLayoutContainer.class);
+
+        mPresenter.acquire(container1, mock(ActivityComponent.class));
+        mPresenter.onControlLostCalled = false;
+        mPresenter.onControlGainedCalled = false;
+
+    /* When */
+        mPresenter.releaseContainer(container2);
+
+    /* Then */
+        assertThat(mPresenter.onControlLostCalled, is(false));
     }
 }

--- a/triad/src/test/java/com/nhaarman/triad/RelativeLayoutContainerTest.java
+++ b/triad/src/test/java/com/nhaarman/triad/RelativeLayoutContainerTest.java
@@ -18,11 +18,6 @@ package com.nhaarman.triad;
 
 import android.app.Activity;
 import android.app.Application;
-import com.nhaarman.triad.ActivityComponentProvider;
-import com.nhaarman.triad.Presenter;
-import com.nhaarman.triad.Screen;
-import com.nhaarman.triad.ScreenProvider;
-import com.nhaarman.triad.TriadProvider;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -83,6 +78,6 @@ public class RelativeLayoutContainerTest {
         mRelativeLayoutContainer.onDetachedFromWindow();
 
         /* Then */
-        verify(mPresenterMock).releaseContainer();
+        verify(mPresenterMock).releaseContainer(mRelativeLayoutContainer);
     }
 }


### PR DESCRIPTION
This prevents a delayed `onDetachedFromWindow()` call
to cause a wrong `onControlLost()` call.