### PR TITLE
Don't try to cast an edit mode's Context

### DIFF
--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterLinearLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterLinearLayoutContainer.kt
@@ -30,7 +30,7 @@ abstract class AdapterLinearLayoutContainer<P : Presenter<*, ActivityComponent>,
 @JvmOverloads constructor(context: Context, attrs: AttributeSet?, defStyle: Int = 0) : LinearLayout(context, attrs, defStyle),
       AdapterContainer<P> {
 
-    private val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context) }
+    private val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context, this) }
 
     private var attachedToWindow: Boolean = false
 

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterRelativeLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/AdapterRelativeLayoutContainer.kt
@@ -30,7 +30,7 @@ abstract class AdapterRelativeLayoutContainer<P : Presenter<*, ActivityComponent
 @JvmOverloads constructor(context: Context, attrs: AttributeSet?, defStyle: Int = 0) : RelativeLayout(context, attrs, defStyle),
       AdapterContainer<P> {
 
-    private val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context) }
+    private val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context, this) }
 
     private var attachedToWindow: Boolean = false
 

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/LinearLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/LinearLayoutContainer.kt
@@ -24,7 +24,7 @@ abstract class LinearLayoutContainer<P : Presenter<*, ActivityComponent>, Activi
 
     val presenter: P by lazy { findPresenter<P>(context, this) }
 
-    val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context) }
+    val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context, this) }
 
     @Suppress("UNCHECKED_CAST")
     override fun onAttachedToWindow() {

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/ListViewContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/ListViewContainer.kt
@@ -29,7 +29,7 @@ abstract class ListViewContainer<P : Presenter<*, ActivityComponent>, ActivityCo
 @JvmOverloads constructor(context: Context, attrs: AttributeSet?, defStyle: Int = 0) : ListView(context, attrs, defStyle), Container {
 
     val presenter: P by lazy { findPresenter<P>(context, this) }
-    val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context) }
+    val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context, this) }
 
     @Suppress("UNCHECKED_CAST")
     override fun onAttachedToWindow() {

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/RelativeLayoutContainer.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/RelativeLayoutContainer.kt
@@ -33,7 +33,7 @@ abstract class RelativeLayoutContainer<P : Presenter<*, ActivityComponent>, Acti
      */
     val presenter: P by lazy { findPresenter<P>(context, this) }
 
-    val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context) }
+    val activityComponent: ActivityComponent by lazy { findActivityComponent<ActivityComponent>(context, this) }
 
     @Suppress("UNCHECKED_CAST")
     override fun onAttachedToWindow() {

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/TriadUtil.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/TriadUtil.kt
@@ -23,7 +23,9 @@ import android.view.View
 
 
 @Suppress("UNCHECKED_CAST")
-fun <ActivityComponent> findActivityComponent(context: Context): ActivityComponent {
+fun <ActivityComponent> findActivityComponent(context: Context, view: View): ActivityComponent {
+    if (view.isInEditMode) return null as ActivityComponent
+
     var baseContext = context
     while (baseContext !is Activity && baseContext is ContextWrapper) {
         baseContext = baseContext.baseContext
@@ -38,6 +40,8 @@ fun <ActivityComponent> findActivityComponent(context: Context): ActivityCompone
 
 @Suppress("UNCHECKED_CAST", "PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 fun <P : Presenter<*, *>> findPresenter(context: Context, view: View): P {
+    if (view.isInEditMode) return null as P
+
     var baseContext = context
     while (baseContext !is Activity && baseContext is ContextWrapper) {
         baseContext = baseContext.baseContext

--- a/triad/src/main/java/com/nhaarman/triad/AdapterLinearLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/AdapterLinearLayoutContainer.java
@@ -53,7 +53,7 @@ public abstract class AdapterLinearLayoutContainer
     public AdapterLinearLayoutContainer(@NonNull final Context context, @Nullable final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
 
-        mActivityComponent = findActivityComponent(context);
+        mActivityComponent = findActivityComponent(context, this);
     }
 
     /**

--- a/triad/src/main/java/com/nhaarman/triad/AdapterRelativeLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/AdapterRelativeLayoutContainer.java
@@ -53,7 +53,7 @@ public abstract class AdapterRelativeLayoutContainer
     public AdapterRelativeLayoutContainer(@NonNull final Context context, @Nullable final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
 
-        mActivityComponent = findActivityComponent(context);
+        mActivityComponent = findActivityComponent(context, this);
     }
 
     /**

--- a/triad/src/main/java/com/nhaarman/triad/LinearLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/LinearLayoutContainer.java
@@ -50,7 +50,7 @@ public abstract class LinearLayoutContainer
     public LinearLayoutContainer(@NonNull final Context context, @Nullable final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
 
-        mActivityComponent = findActivityComponent(context);
+        mActivityComponent = findActivityComponent(context, this);
     }
 
     /**

--- a/triad/src/main/java/com/nhaarman/triad/ListViewContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/ListViewContainer.java
@@ -50,7 +50,7 @@ public abstract class ListViewContainer
     public ListViewContainer(@NonNull final Context context, @Nullable final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
 
-        mActivityComponent = findActivityComponent(context);
+        mActivityComponent = findActivityComponent(context, this);
     }
 
     /**

--- a/triad/src/main/java/com/nhaarman/triad/RelativeLayoutContainer.java
+++ b/triad/src/main/java/com/nhaarman/triad/RelativeLayoutContainer.java
@@ -51,7 +51,7 @@ public abstract class RelativeLayoutContainer
     public RelativeLayoutContainer(@NonNull final Context context, @Nullable final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
 
-        mActivityComponent = findActivityComponent(context);
+        mActivityComponent = findActivityComponent(context, this);
     }
 
     /**

--- a/triad/src/main/java/com/nhaarman/triad/TriadUtil.java
+++ b/triad/src/main/java/com/nhaarman/triad/TriadUtil.java
@@ -21,8 +21,6 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.support.annotation.NonNull;
 import android.view.View;
-import kotlin.jvm.JvmOverloads;
-import kotlin.jvm.Throws;
 
 /**
  * An utility class that retrieves the ActivityComponent and Presenter using a Context instance.
@@ -33,7 +31,9 @@ public class TriadUtil {
     }
 
     @NonNull
-    public static <ActivityComponent> ActivityComponent findActivityComponent(@NonNull final Context context) {
+    public static <ActivityComponent> ActivityComponent findActivityComponent(@NonNull final Context context, @NonNull final View view) {
+        if(view.isInEditMode()) return null;
+
         Context baseContext = context;
         while (!(baseContext instanceof Activity) && baseContext instanceof ContextWrapper) {
             baseContext = ((ContextWrapper) baseContext).getBaseContext();
@@ -51,6 +51,8 @@ public class TriadUtil {
 
     @NonNull
     public static <P extends Presenter<?, ?>> P findPresenter(@NonNull final Context context, final View view) {
+        if(view.isInEditMode()) return null;
+
         Context baseContext = context;
         while (!(baseContext instanceof Activity) && baseContext instanceof ContextWrapper) {
             baseContext = ((ContextWrapper) baseContext).getBaseContext();


### PR DESCRIPTION
This prevents the layout editor from crashing in Android Studio.