### PR TITLE
Delay backstack updating when transition is done.

### DIFF
--- a/triad-core/src/main/kotlin/com/nhaarman/triad/ScreenProvider.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/ScreenProvider.kt
@@ -18,5 +18,5 @@ package com.nhaarman.triad
 
 interface ScreenProvider<ApplicationComponent : Any> {
 
-    val currentScreen: Screen<ApplicationComponent>?
+    val currentScreen: Screen<ApplicationComponent>
 }

--- a/triad-core/src/main/kotlin/com/nhaarman/triad/TriadActivity.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/TriadActivity.kt
@@ -31,7 +31,7 @@ abstract class TriadActivity<ApplicationComponent : Any, ActivityComponent> : Ac
 
     private val delegate = TriadDelegate.createFor<ApplicationComponent>(this)
 
-    override val currentScreen: Screen<ApplicationComponent>?
+    override val currentScreen: Screen<ApplicationComponent>
         get() = delegate.currentScreen
 
     override val activityComponent: ActivityComponent by lazy {

--- a/triad-core/src/main/kotlin/com/nhaarman/triad/TriadDelegate.kt
+++ b/triad-core/src/main/kotlin/com/nhaarman/triad/TriadDelegate.kt
@@ -66,8 +66,9 @@ class TriadDelegate<ApplicationComponent : Any> internal constructor(
         (activity.application as TriadProvider).triad
     }
 
-    val currentScreen: Screen<ApplicationComponent>?
-        get() = triad.backstack.current<ApplicationComponent>()?.screen
+    var _currentScreen: Screen<ApplicationComponent> ? = null
+    val currentScreen: Screen<ApplicationComponent>
+        get() = _currentScreen!!
 
     /**
      * An optional [OnScreenChangedListener] that is notified of screen changes.
@@ -98,7 +99,7 @@ class TriadDelegate<ApplicationComponent : Any> internal constructor(
 
     fun onPause() {
         resumed = false
-        currentScreen?.onDetach(activity)
+        _currentScreen?.onDetach(activity)
     }
 
     fun onDestroy() {
@@ -126,8 +127,10 @@ class TriadDelegate<ApplicationComponent : Any> internal constructor(
 
         override fun forward(newScreen: Screen<ApplicationComponent>, animator: TransitionAnimator?, onComplete: () -> Unit) {
             rootView.getChildAt(0)?.let { view ->
-                currentScreen?.saveState(view)
+                _currentScreen?.saveState(view)
             }
+
+            _currentScreen = newScreen
 
             val oldView = rootView.getChildAt(0)
             val newView = newScreen.createView(rootView)
@@ -145,6 +148,8 @@ class TriadDelegate<ApplicationComponent : Any> internal constructor(
         }
 
         override fun backward(newScreen: Screen<ApplicationComponent>, animator: TransitionAnimator?, onComplete: () -> Unit) {
+            _currentScreen = newScreen
+
             val oldView = rootView.getChildAt(0)
             val newView = newScreen.createView(rootView).apply {
                 newScreen.restoreState(this)
@@ -163,6 +168,8 @@ class TriadDelegate<ApplicationComponent : Any> internal constructor(
         }
 
         override fun replace(newScreen: Screen<ApplicationComponent>, animator: TransitionAnimator?, onComplete: () -> Unit) {
+            _currentScreen = newScreen
+
             val oldView = rootView.getChildAt(0)
             val newView = newScreen.createView(rootView)
 

--- a/triad-kotlin-appcompat-v7/src/main/kotlin/com/nhaarman/triad/TriadAppCompatActivity.kt
+++ b/triad-kotlin-appcompat-v7/src/main/kotlin/com/nhaarman/triad/TriadAppCompatActivity.kt
@@ -51,7 +51,7 @@ abstract class TriadAppCompatActivity<ApplicationComponent : Any, ActivityCompon
      */
     protected abstract fun createActivityComponent(): ActivityComponent
 
-    override val currentScreen: Screen<ApplicationComponent>?
+    override val currentScreen: Screen<ApplicationComponent>
         get() = delegate.currentScreen
 
     override fun onBackPressed() {

--- a/triad-kotlin/src/main/kotlin/com/nhaarman/triad/TriadUtil.kt
+++ b/triad-kotlin/src/main/kotlin/com/nhaarman/triad/TriadUtil.kt
@@ -49,7 +49,7 @@ fun <P : Presenter<*, *>> findPresenter(context: Context, view: View): P {
 
     if (baseContext is ScreenProvider<*>) {
         try {
-            return baseContext.currentScreen?.getPresenter(view.id) as P
+            return baseContext.currentScreen.getPresenter(view.id) as P
         } catch(t: Throwable) {
             val e = PresenterCreationFailedError("Could not create presenter for:\n    $view\nCaused by: $t", t.cause)
             (e as java.lang.Throwable).stackTrace = t.stackTrace


### PR DESCRIPTION
Otherwise screens can become tangled.