### PR TITLE
Start with screens and backstacks from intents

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,4 @@
+-keep,allowshrinking class * extends com.nhaarman.triad.Screen
+-keepclasseswithmembers class * {
+    public static final com.nhaarman.triad.Screen create();
+}

--- a/triad-appcompat-v7/src/main/java/com/nhaarman/triad/TriadAppCompatActivity.java
+++ b/triad-appcompat-v7/src/main/java/com/nhaarman/triad/TriadAppCompatActivity.java
@@ -44,7 +44,7 @@ public abstract class TriadAppCompatActivity<ApplicationComponent, ActivityCompo
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        delegate.onCreate();
+        delegate.onCreate(getIntent());
     }
 
     @Override

--- a/triad-core/build.gradle
+++ b/triad-core/build.gradle
@@ -11,6 +11,12 @@ buildscript {
     }
 }
 
+android {
+    defaultConfig {
+        consumerProguardFiles '../proguard-rules.pro'
+    }
+}
+
 dependencies {
     provided androidSupportAnnotations
     provided jetbrainsAnnotations

--- a/triad-core/src/main/java/com/nhaarman/triad/Triad.java
+++ b/triad-core/src/main/java/com/nhaarman/triad/Triad.java
@@ -20,6 +20,11 @@ public interface Triad {
     void setActivity(@Nullable Activity activity);
 
     /**
+     * Resets Triad to an empty backstack.
+     */
+    void reset();
+
+    /**
      * Initializes the backstack with given Screen. If the backstack is not empty, this call is ignored.
      * This method must be called before any other backstack operation.
      *

--- a/triad-core/src/main/java/com/nhaarman/triad/TriadActivity.java
+++ b/triad-core/src/main/java/com/nhaarman/triad/TriadActivity.java
@@ -44,7 +44,7 @@ public abstract class TriadActivity<ApplicationComponent, ActivityComponent> ext
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        delegate.onCreate();
+        delegate.onCreate(getIntent());
     }
 
     @Override

--- a/triad-core/src/main/java/com/nhaarman/triad/TriadDelegate.java
+++ b/triad-core/src/main/java/com/nhaarman/triad/TriadDelegate.java
@@ -28,6 +28,8 @@ import java.util.Iterator;
 
 import static com.nhaarman.triad.Preconditions.checkNotNull;
 import static com.nhaarman.triad.Preconditions.checkState;
+import static com.nhaarman.triad.TriadIntents.createBackstack;
+import static com.nhaarman.triad.TriadIntents.createScreen;
 
 /**
  * This class represents a delegate which can be used to use Triad in any
@@ -36,7 +38,7 @@ import static com.nhaarman.triad.Preconditions.checkState;
  * When using the {@code TriadDelegate}, you must proxy the following Activity
  * lifecycle methods to it:
  * <ul>
- * <li>{@link #onCreate()}</li>
+ * <li>{@link #onCreate(Intent)}</li>
  * <li>{@link #onResume()}</li>
  * <li>{@link #onDestroy()}</li>
  * <li>{@link #onBackPressed()}</li>
@@ -92,7 +94,7 @@ public class TriadDelegate<ApplicationComponent> {
         return checkNotNull(currentScreen, "Current screen is null.");
     }
 
-    public void onCreate() {
+    public void onCreate(@Nullable final Intent intent) {
         checkState(activity.getApplication() instanceof TriadProvider, "Make sure your Application class implements TriadProvider.");
         checkState(activity.getApplication() instanceof ApplicationComponentProvider, "Make sure your Application class implements ApplicationComponentProvider.");
 
@@ -105,6 +107,16 @@ public class TriadDelegate<ApplicationComponent> {
 
         if (triad.getBackstack().size() > 0 || triad.isTransitioning()) {
             triad.showCurrent();
+        } else if (intent != null) {
+            Screen<?> screen = createScreen(intent);
+            if (screen != null) {
+                triad.startWith(screen);
+            } else {
+                Backstack backstack = createBackstack(intent);
+                if (backstack != null) {
+                    triad.startWith(backstack);
+                }
+            }
         }
     }
 

--- a/triad-core/src/main/java/com/nhaarman/triad/TriadImpl.java
+++ b/triad-core/src/main/java/com/nhaarman/triad/TriadImpl.java
@@ -79,6 +79,15 @@ class TriadImpl implements Triad {
     }
 
     @Override
+    public void reset() {
+        if (transition != null) {
+            transition.cancel();
+            transition = null;
+        }
+        backstack = Backstack.emptyBuilder().build();
+    }
+
+    @Override
     @NonNull
     public Backstack getBackstack() {
         return backstack;

--- a/triad-core/src/main/java/com/nhaarman/triad/TriadIntents.java
+++ b/triad-core/src/main/java/com/nhaarman/triad/TriadIntents.java
@@ -1,0 +1,143 @@
+package com.nhaarman.triad;
+
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class TriadIntents {
+
+    private static final String KEY_SCREEN = "com.nhaarman.triad.screen";
+    private static final String KEY_BACKSTACK = "com.nhaarman.triad.backstack";
+
+    private TriadIntents() {
+    }
+
+    public static void startWith(
+          @NonNull final Intent intent,
+          @NonNull final Class<? extends Screen> screen,
+          @NonNull final Class<? extends Screen>... screens
+    ) {
+        if (screens.length == 0) {
+            intent.putExtra(KEY_SCREEN, screen.getCanonicalName());
+        } else {
+            String[] classNames = new String[screens.length + 1];
+
+            classNames[0] = screen.getCanonicalName();
+            for (int i = 0; i < screens.length; i++) {
+                classNames[i + 1] = screens[i].getCanonicalName();
+            }
+
+            intent.putExtra(KEY_BACKSTACK, classNames);
+        }
+    }
+
+    @Nullable
+    public static Screen<?> createScreen(@NonNull final Intent intent) {
+        String screenClassName = intent.getStringExtra(KEY_SCREEN);
+        if (screenClassName == null) return null;
+
+        return createScreen(intent, screenClassName);
+    }
+
+    @NonNull
+    private static Screen<?> createScreen(@NonNull final Intent intent, @NonNull final String screenClassName) {
+        Class<?> screenClass = createClassForName(screenClassName);
+        if (screenClass == null) {
+            throw new IllegalStateException("Could not create a class for " + screenClassName);
+        }
+
+        Screen<?> screenInstance = createScreenInstanceUsingConstructor(screenClass);
+        if (screenInstance != null) return screenInstance;
+
+        screenInstance = createScreenInstanceUsingCreateMethod(screenClass, intent);
+        if (screenInstance != null) return screenInstance;
+
+        Class<?> kotlinScreenClass = createClassForName(screenClassName + "Kt");
+        if (kotlinScreenClass == null) {
+            throw new IllegalStateException("Could not find empty constructor, `create()` or `create(Intent)` method for class " + screenClassName);
+        }
+
+        screenInstance = createScreenInstanceUsingCreateMethod(kotlinScreenClass, intent);
+        if (screenInstance != null) return screenInstance;
+
+        throw new IllegalStateException("Could not find empty constructor, `create()` or `create(Intent)` method for class " + screenClassName);
+    }
+
+    @Nullable
+    public static Backstack createBackstack(@NonNull final Intent intent) {
+        String[] backstack = intent.getStringArrayExtra(KEY_BACKSTACK);
+        if (backstack == null) return null;
+
+        Screen<?>[] screens = new Screen[backstack.length];
+        for (int i = 0; i < backstack.length; i++) {
+            screens[i] = createScreen(intent, backstack[i]);
+        }
+
+        return Backstack.of(screens);
+    }
+
+    @Nullable
+    private static Class<?> createClassForName(@NonNull final String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            Log.w("Triad", "Could not create class for name " + className, e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Screen<?> createScreenInstanceUsingConstructor(@NonNull final Class<?> screenClass) {
+        Constructor<?> constructor = parameterlessConstructor(screenClass);
+        if (constructor == null) return null;
+
+        try {
+            return (Screen<?>) screenClass.newInstance();
+        } catch (InstantiationException e) {
+            Log.w("Triad", "Could not create screen instance for " + screenClass.getCanonicalName(), e);
+            return null;
+        } catch (IllegalAccessException e) {
+            Log.w("Triad", "Could not create screen instance for " + screenClass.getCanonicalName(), e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Constructor<?> parameterlessConstructor(@NonNull final Class<?> screenClass) {
+        try {
+            return screenClass.getConstructor();
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Screen<?> createScreenInstanceUsingCreateMethod(@NonNull final Class<?> screenClass, @NonNull final Intent intent) {
+        Method createMethod = null;
+        for (final Method method : screenClass.getMethods()) {
+            if (method.getName().equals("create")) {
+                createMethod = method;
+            }
+        }
+
+        if (createMethod == null) return null;
+
+        try {
+            if (createMethod.getParameterTypes().length == 1) {
+                return (Screen<?>) createMethod.invoke(null, intent);
+            } else {
+                return (Screen<?>) createMethod.invoke(null);
+            }
+        } catch (InvocationTargetException e) {
+            Log.w("Triad", "Could not create screen instance for " + screenClass.getCanonicalName(), e);
+            return null;
+        } catch (IllegalAccessException e) {
+            Log.w("Triad", "Could not create screen instance for " + screenClass.getCanonicalName(), e);
+            return null;
+        }
+    }
+}

--- a/triad-core/src/test/java/com/nhaarman/triad/TriadDelegateTest.kt
+++ b/triad-core/src/test/java/com/nhaarman/triad/TriadDelegateTest.kt
@@ -64,7 +64,7 @@ class TriadDelegateTest {
 
         val delegate = TriadDelegate.createFor<Any>(activity, mock())
         whenever((mApplication as TriadProvider).triad).thenReturn(TriadFactory.newInstance(Backstack.of(mScreen1, mScreen2), mListener))
-        delegate.onCreate()
+        delegate.onCreate(null)
 
         /* When */
         delegate.onDestroy()
@@ -81,7 +81,7 @@ class TriadDelegateTest {
 
         val delegate = TriadDelegate.createFor<Any>(activity, mock())
         whenever((mApplication as TriadProvider).triad).thenReturn(TriadFactory.newInstance(Backstack.of(mScreen1, mScreen2), mListener))
-        delegate.onCreate()
+        delegate.onCreate(null)
 
         /* When */
         delegate.onDestroy()

--- a/triad-kotlin-appcompat-v7/src/main/kotlin/com/nhaarman/triad/TriadAppCompatActivity.kt
+++ b/triad-kotlin-appcompat-v7/src/main/kotlin/com/nhaarman/triad/TriadAppCompatActivity.kt
@@ -33,7 +33,7 @@ abstract class TriadAppCompatActivity<ApplicationComponent : Any, ActivityCompon
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        delegate.onCreate()
+        delegate.onCreate(intent)
     }
 
     override fun onResume() {


### PR DESCRIPTION
This enables the use of the Intent an Activity is
started with to let Triad start with given screens.
In order for this to work, the Screen class must
have one of the following (in order of priority):

- Either a parameterless constructor
- A static function create(Intent)
- A top level function create(Intent) in a file called "${screen}Kt".

The Intent passed to the create(Intent) function is the
same Intent used to start the Activity.

For example, in a file called MyScreen.kt:

```
fun create(intent: Intent) = MyScreen("Name")

class MyScreen(val name: String) : Screen<ApplicationComponent>() {
  /* ... */
}
```